### PR TITLE
fix: swap leveldown/level.js for level

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
 ## Table of Contents
 
 - [js-datastore-level](#js-datastore-level)
-  - [Lead Maintainer](#lead-maintainer)
-  - [Table of Contents](#table-of-contents)
-  - [Install](#install)
-  - [Usage](#usage)
-    - [Browser Shimming Leveldown](#browser-shimming-leveldown)
-    - [Database names](#database-names)
-  - [Contribute](#contribute)
-  - [License](#license)
+  - [Lead Maintainer](#Lead-Maintainer)
+  - [Table of Contents](#Table-of-Contents)
+  - [Install](#Install)
+  - [Usage](#Usage)
+    - [Browser Shimming Leveldown](#Browser-Shimming-Leveldown)
+    - [Database names](#Database-names)
+  - [Contribute](#Contribute)
+  - [License](#License)
 
 ## Install
 
@@ -41,18 +41,20 @@ $ npm install datastore-level
 ```js
 const LevelStore = require('datastore-level')
 
-// Default using leveldown as backend
+// Default using level as backend for node or the browser
 const store = new LevelStore('path/to/store')
 
-// use in the browser with level.js
-const browserStore = new LevelStore('my/db/name', {db: require('level-js')})
-
 // another leveldown compliant backend like memdown
-const memStore = new LevelStore('my/mem/store', {db: require('memdown')})
+const memStore = new LevelStore('my/mem/store', {
+  db: require('level-mem')
+})
 ```
 
 ### Browser Shimming Leveldown
-As `leveldown` does not work in the browser, `LevelStore` takes advantage of the browser property in package.json to shim `level-js` in its place. Most modern bundlers such as webpack, will see the shim and replace it for use in the browser. If you are using a bundler that does not support pkg.browser, you will need to handle the shimming yourself, as was the case with versions of `LevelStore` 0.7.0 and earlier.
+
+`LevelStore` uses the `level` module to automatically use `level.js` if a modern bundler is used which can detect bundle targets based on the `pkg.browser` property in your `package.json`.
+
+If you are using a bundler that does not support `pkg.browser`, you will need to handle the shimming yourself, as was the case with versions of `LevelStore` 0.7.0 and earlier.
 
 ### Database names
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "cids": "~0.7.1",
     "dirty-chai": "^2.0.1",
     "level-mem": "^4.0.0",
-    "memdown": "^4.0.0",
     "rimraf": "^2.6.2"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "description": "Datastore implementation with level(up|down) backend",
   "leadMaintainer": "Pedro Teixeira <pedro@protocol.ai>",
   "main": "src/index.js",
-  "browser": {
-    "leveldown": "level-js"
-  },
   "scripts": {
     "test": "aegir test",
     "test:node": "aegir test -t node",
@@ -41,17 +38,15 @@
   "homepage": "https://github.com/ipfs/js-datastore-level#readme",
   "dependencies": {
     "datastore-core": "~0.7.0",
-    "encoding-down": "^6.0.2",
     "interface-datastore": "~0.7.0",
-    "level-js": "^4.0.1",
-    "leveldown": "^5.0.0",
-    "levelup": "^4.0.1"
+    "level": "^5.0.1"
   },
   "devDependencies": {
     "aegir": "^19.0.3",
     "chai": "^4.2.0",
     "cids": "~0.7.1",
     "dirty-chai": "^2.0.1",
+    "level-mem": "^4.0.0",
     "memdown": "^4.0.0",
     "rimraf": "^2.6.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const { Key, Errors, utils } = require('interface-datastore')
 const { filter, map, take, sortAll } = utils
-const { promisify } = require('util')
 
 /**
  * A datastore backed by leveldb.
@@ -23,13 +22,6 @@ class LevelDatastore {
       valueEncoding: 'binary',
       compression: false // same default as go
     })
-
-    this.db.put = promisify(this.db.put)
-    this.db.get = promisify(this.db.get)
-    this.db.del = promisify(this.db.del)
-    this.db.open = promisify(this.db.open)
-    this.db.close = promisify(this.db.close)
-    this.db.batch = promisify(this.db.batch)
   }
 
   async open () {

--- a/test/browser.js
+++ b/test/browser.js
@@ -3,10 +3,7 @@
 
 const { MountDatastore } = require('datastore-core')
 const { Key } = require('interface-datastore')
-
-// leveldown will be swapped for level-js
-const leveljs = require('leveldown')
-
+const leveljs = require('level')
 const LevelStore = require('../src')
 
 describe('LevelDatastore', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,8 +4,8 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const memdown = require('memdown')
-const LevelDown = require('leveldown')
+const levelmem = require('level-mem')
+const level = require('level')
 const os = require('os')
 const LevelStore = require('../src')
 
@@ -15,7 +15,6 @@ describe('LevelDatastore', () => {
       const levelStore = new LevelStore('init-default')
       await levelStore.open()
 
-      expect(levelStore.db.db.db instanceof LevelDown).to.equal(true)
       expect(levelStore.db.options).to.include({
         createIfMissing: true,
         errorIfExists: false
@@ -27,14 +26,13 @@ describe('LevelDatastore', () => {
 
     it('should be able to override the database', async () => {
       const levelStore = new LevelStore('init-default', {
-        db: memdown,
+        db: levelmem,
         createIfMissing: true,
         errorIfExists: true
       })
 
       await levelStore.open()
 
-      expect(levelStore.db.db.db instanceof memdown).to.equal(true)
       expect(levelStore.db.options).to.include({
         createIfMissing: true,
         errorIfExists: true
@@ -42,7 +40,7 @@ describe('LevelDatastore', () => {
     })
   })
 
-  ;[memdown, LevelDown].forEach(database => {
+  ;[levelmem, level].forEach(database => {
     describe(`interface-datastore ${database.name}`, () => {
       require('interface-datastore/src/tests')({
         setup: () => new LevelStore(`${os.tmpdir()}/datastore-level-test-${Math.random()}`, { db: database }),

--- a/test/node.js
+++ b/test/node.js
@@ -17,7 +17,7 @@ describe('LevelDatastore', () => {
   describe('interface-datastore (leveldown)', () => {
     const dir = utils.tmpdir()
     require('interface-datastore/src/tests')({
-      setup: () => new LevelStore(dir, { db: require('leveldown') }),
+      setup: () => new LevelStore(dir, { db: require('level') }),
       teardown: () => promisify(rimraf)(dir)
     })
   })
@@ -34,17 +34,17 @@ describe('LevelDatastore', () => {
         return new MountDatastore([{
           prefix: new Key('/a'),
           datastore: new LevelStore(dirs[0], {
-            db: require('leveldown')
+            db: require('level')
           })
         }, {
           prefix: new Key('/q'),
           datastore: new LevelStore(dirs[1], {
-            db: require('leveldown')
+            db: require('level')
           })
         }, {
           prefix: new Key('/z'),
           datastore: new LevelStore(dirs[2], {
-            db: require('leveldown')
+            db: require('level')
           })
         }])
       },
@@ -56,7 +56,7 @@ describe('LevelDatastore', () => {
 
   it.skip('interop with go', async () => {
     const store = new LevelStore(path.join(__dirname, 'test-repo', 'datastore'), {
-      db: require('leveldown')
+      db: require('level')
     })
 
     let cids = []


### PR DESCRIPTION
The `level` module bundles `leveldown`, `encoding-down` and `levelup`, as well as substituting `level.js` for `leveldown` in the browser.

This change uses `level` over all those other modules.