### PR TITLE
fix: init db in overridable method for easier extending

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,11 @@ class LevelDatastore {
       database = require('level')
     }
 
-    this.db = database(path, {
+    this.db = this._initDb(database, path, opts)
+  }
+
+  _initDb (database, path, opts) {
+    return database(path, {
       ...opts,
       valueEncoding: 'binary',
       compression: false // same default as go


### PR DESCRIPTION
Sometimes you might want to pass a fully initialised level instance to the LevelDatastore constructor or use a singleton or something else.

Instead of creating the level instance in the constructor this change adds a method that child classes can override to tweak the behaviour as they see fit.