### PR TITLE
Optimize prefix search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,12 +105,23 @@ class LevelDatastore {
       values = !q.keysOnly
     }
 
+    let opts = {
+      keys: true,
+      values: values,
+      keyAsBuffer: true
+    }
+
+    // Let the db do the prefix matching
+    if (q.prefix != null) {
+      const prefix = q.prefix.toString()
+      // Match keys greater than or equal to `prefix` and
+      opts.gte = prefix
+      // less than `prefix` + \xFF (hex escape sequence)
+      opts.lt = prefix + '\xFF'
+    }
+
     let it = levelIteratorToIterator(
-      this.db.db.iterator({
-        keys: true,
-        values: values,
-        keyAsBuffer: true
-      })
+      this.db.db.iterator(opts)
     )
 
     it = map(it, ({ key, value }) => {
@@ -120,10 +131,6 @@ class LevelDatastore {
       }
       return res
     })
-
-    if (q.prefix != null) {
-      it = filter(it, e => e.key.toString().startsWith(q.prefix))
-    }
 
     if (Array.isArray(q.filters)) {
       it = q.filters.reduce((it, f) => filter(it, f), it)

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class LevelDatastore {
     }
 
     let it = levelIteratorToIterator(
-      this.db.db.iterator(opts)
+      this.db.iterator(opts)
     )
 
     it = map(it, ({ key, value }) => {

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ class LevelDatastore {
       values = !q.keysOnly
     }
 
-    let opts = {
+    const opts = {
       keys: true,
       values: values,
       keyAsBuffer: true


### PR DESCRIPTION
This improves prefix search slightly by taking advantage of level's built-in query parameters. In particular, it uses `gte` and `lt` keys, and lets the db do the prefix searching rather than using a filter. In my (albeit rough) tests, this can lead to pretty significant speedups in cases with many entries with varying key prefixes. The 'trick' is to set `gte` to prefix and `lt` to prefix plus the  '\xFF' hex escape sequence. Passes tests and does not change the API (though actually I did sneak in a `toString()` call to support `Key`-based prefixes). If this is something worth officially supporting, I could also update the docs.