### PR TITLE
fix: remove node buffers

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+  webpack: {
+    node: {
+      // this is needed until level stops using node buffers in browser code
+      Buffer: true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-level#readme",
   "dependencies": {
-    "datastore-core": "ipfs/js-datastore-core#fix/remove-node-buffers",
-    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "datastore-core": "^2.0.0",
+    "interface-datastore": "^2.0.0",
     "level": "^5.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-level#readme",
   "dependencies": {
-    "datastore-core": "^1.1.0",
-    "interface-datastore": "^1.0.2",
-    "level": "^5.0.1"
+    "datastore-core": "ipfs/js-datastore-core#fix/remove-node-buffers",
+    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "level": "^5.0.2"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "chai": "^4.2.0",
-    "cids": "^0.8.0",
+    "cids": "^0.8.3",
     "dirty-chai": "^2.0.1",
     "level-mem": "^5.0.1",
     "rimraf": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "datastore-core": "ipfs/js-datastore-core#fix/remove-node-buffers",
     "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
-    "level": "^5.0.2"
+    "level": "^5.0.1"
   },
   "devDependencies": {
     "aegir": "^25.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ class LevelDatastore extends Adapter {
     it = map(it, ({ key, value }) => {
       const res = { key: new Key(key, false) }
       if (values) {
-        res.value = Buffer.from(value)
+        res.value = value
       }
       return res
     })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,8 +6,8 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const levelmem = require('level-mem')
 const level = require('level')
-const os = require('os')
 const LevelStore = require('../src')
+const { utils } = require('interface-datastore')
 
 describe('LevelDatastore', () => {
   describe('initialization', () => {
@@ -43,7 +43,7 @@ describe('LevelDatastore', () => {
   ;[levelmem, level].forEach(database => {
     describe(`interface-datastore ${database.name}`, () => {
       require('interface-datastore/src/tests')({
-        setup: () => new LevelStore(`${os.tmpdir()}/datastore-level-test-${Math.random()}`, { db: database }),
+        setup: () => new LevelStore(utils.tmpdir(), { db: database }),
         teardown () {}
       })
     })

--- a/test/node.js
+++ b/test/node.js
@@ -63,7 +63,7 @@ describe('LevelDatastore', () => {
     const cids = []
 
     for await (const e of store.query({})) {
-      cids.push(new CID(1, 'dag-cbor', e.key.toBuffer()))
+      cids.push(new CID(1, 'dag-cbor', e.key.uint8Array()))
     }
 
     expect(cids[0].version).to.be.eql(0)


### PR DESCRIPTION
This module didn't have a lot of buffer use in the first place,
but we remove any references to buffers in favour of Uint8Arrays.

When querying, values come back as Buffers which are Uint8Arrays so
the conversion was unnecessary.

Depends on:

- [x] https://github.com/ipfs/interface-datastore/pull/43
- [x] https://github.com/ipfs/js-datastore-core/pull/27

BREAKING CHANGE: remove node buffers in favour of Uint8Arrays